### PR TITLE
Sign message with key path

### DIFF
--- a/example.html
+++ b/example.html
@@ -28,6 +28,10 @@
     <input type="text" id="path">
     <input type="button" onclick="Ledger.getXPubKey(document.getElementById('path').value)" value="Get xpubkey">
     <p>
+    <input type="text" id="message_path">
+    <textarea id="message"></textarea>
+    <input type="button" onclick="Ledger.signMessage(document.getElementById('message_path').value, document.getElementById('message').value)" value="Sign message">
+    <p>
     <input type="button" onclick="p2sh()" value="Sign P2SH">
     <script>
       function callback(event) {

--- a/ledger.js
+++ b/ledger.js
@@ -32,6 +32,9 @@ var Ledger = {
   getXPubKey: function(path) {
     Ledger._messageAfterSession({ command:"get_xpubkey", path:path })
   },
+  signMessage: function(path, message) {
+    Ledger._messageAfterSession({ command:"sign_message", path:path, message:message })
+  },
   signP2SH: function(inputs, scripts, outputs_number, outputs_script, paths) {
     Ledger._messageAfterSession({ command:"sign_p2sh", inputs: inputs, scripts: scripts, outputs_number: outputs_number, outputs_script: outputs_script, paths: paths })
   },


### PR DESCRIPTION
This PR adds the `sign_message` API that is exposed in ledger-wallet with this pull request:  https://github.com/LedgerHQ/ledger-wallet-chrome/pull/22

Here is an example: 

```javascript
Ledger.signMessage("m/1/2/3", "this is a test message")
```

The responding message would be:

```javascript
{"command":"sign_message","success":true, "signature": <signature>, "address": <address>}
```